### PR TITLE
Make `gpu_cache` optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: rust
+script:
+  - cargo build --verbose
+  - cargo test --verbose
+  - cargo build --verbose --features="gpu_cache"
+  - cargo test --verbose --features="gpu_cache"
 after_success: |
   [ $TRAVIS_BRANCH = master ] &&
   [ $TRAVIS_PULL_REQUEST = false ] &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = ["/fonts/**"]
 [dependencies]
 arrayvec = "0.4"
 stb_truetype = "0.2"
-linked-hash-map = "0.5"
+linked-hash-map = { version = "0.5", optional = true }
 ordered-float = "0.5"
 
 [dev-dependencies]
@@ -33,3 +33,11 @@ unicode-normalization = "0.1"
 [features]
 # Compiles benchmark code, to be avoided normally as this currently requires nightly rust
 bench = []
+gpu_cache = ["linked-hash-map"]
+
+[[example]]
+name = "gpu_cache"
+required-features = ["gpu_cache"]
+
+[[example]]
+name = "simple"

--- a/src/gpu_cache.rs
+++ b/src/gpu_cache.rs
@@ -23,10 +23,12 @@
 //! then when it's time to render call `Cache::rect_for` to get the UV coordinates in the cache texture for
 //! each glyph. For a concrete use case see the `gpu_cache` example.
 
+extern crate linked_hash_map;
+
 use ::{PositionedGlyph, Rect, Scale, GlyphId, Vector};
 use std::collections::{HashMap, HashSet, BTreeMap};
 use std::collections::Bound::{Included, Unbounded};
-use linked_hash_map::LinkedHashMap;
+use self::linked_hash_map::LinkedHashMap;
 use ordered_float::OrderedFloat;
 use std::cmp::{PartialEq, Eq, Ord, PartialOrd, Ordering};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,12 +90,12 @@ extern crate unicode_normalization;
 
 extern crate arrayvec;
 extern crate stb_truetype;
-extern crate linked_hash_map;
 extern crate ordered_float;
 
 mod geometry;
 mod rasterizer;
 
+#[cfg(feature = "gpu_cache")]
 pub mod gpu_cache;
 
 use std::sync::Arc;


### PR DESCRIPTION
I think `gpu_cache` module and related features should be optional, so how is it to use "feature" feature?
~~This change will help solve also #12, by not turning on the `gpu_cache` feature on Redox os.~~
The feature is (currently) disabled by default, but can be enabled by building with `cargo build --features="gpu_cache"`, and `gpu_cache` example can run by `cargo run --example=gpu_cache --features="gpu_cache"`.
(See http://doc.crates.io/manifest.html#the-features-section )
