### PR TITLE
Derive Debug for many structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["examples/*.ttf"]
 
 [dependencies]
 arrayvec = "^0.3.13"
-stb_truetype = "^0.2"
+stb_truetype = "^0.2.2"
 linked-hash-map = "0.0.10"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,10 +99,10 @@ use stb_truetype as tt;
 
 /// A collection of fonts read straight from a font file's data. The data in the collection is not validated.
 /// This structure may or may not own the font data.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct FontCollection<'a>(SharedBytes<'a>);
 /// A single font. This may or may not own the font data.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Font<'a> {
     info: tt::FontInfo<SharedBytes<'a>>
 }
@@ -110,7 +110,7 @@ pub struct Font<'a> {
 /// `SharedBytes` handles the lifetime of font data used in RustType. The data is either a shared
 /// reference to externally owned data, or managed by reference counting. `SharedBytes` can be
 /// conveniently used with `From` and `Into`, and dereferences to the contained bytes.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum SharedBytes<'a> {
     ByRef(&'a [u8]),
     ByArc(Arc<Box<[u8]>>)
@@ -166,17 +166,18 @@ pub struct GlyphId(pub u32);
 ///
 /// A `Glyph` does not have an inherent scale or position associated with it. To augment a glyph with a
 /// size, give it a scale using `scaled`. You can then position it using `positioned`.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Glyph<'a> {
     inner: GlyphInner<'a>
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 enum GlyphInner<'a> {
     Proxy(&'a Font<'a>, u32),
     Shared(Arc<SharedGlyphData>)
 }
 
+#[derive(Debug)]
 struct SharedGlyphData {
     id: u32,
     extents: Option<Rect<i32>>,
@@ -207,7 +208,7 @@ pub struct VMetrics {
 }
 /// A glyph augmented with scaling information. You can query such a glyph for information that depends
 /// on the scale of the glyph.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ScaledGlyph<'a> {
     g: Glyph<'a>,
     api_scale: Scale,
@@ -215,7 +216,7 @@ pub struct ScaledGlyph<'a> {
 }
 /// A glyph augmented with positioning and scaling information. You can query such a glyph for information
 /// that depends on the scale and position of the glyph.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PositionedGlyph<'a> {
     sg: ScaledGlyph<'a>,
     position: Point<f32>,


### PR DESCRIPTION
In order for PistonDevelopers/conrod#839 to have some full Debug implementations, this crate needs to be updated and released.

The PR build will fail until https://github.com/dylanede/stb_truetype-rs/pull/6 is merged and a new version published (I did an anticipatory dependency bump to version 0.2.2)