### PR TITLE
Use `position` instead of `pixel_bounding_box` for width calculation in example

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -27,8 +27,7 @@ fn main() {
 
     // Find the most visually pleasing width to display
     let width = glyphs.iter().rev()
-        .filter_map(|g| g.pixel_bounding_box()
-                    .map(|b| b.min.x as f32 + g.unpositioned().h_metrics().advance_width))
+        .map(|g| g.position().x as f32 + g.unpositioned().h_metrics().advance_width)
         .next().unwrap_or(0.0).ceil() as usize;
 
     println!("width: {}, height: {}", width, pixel_height);


### PR DESCRIPTION
This respects trailing whitespace. With the previous method, concatenating “Hello ” and “World!” yielded “HelloWorld!”.