### PR TITLE
Attempt at fixing rasterize returning negative values

### DIFF
--- a/src/rasterizer.rs
+++ b/src/rasterizer.rs
@@ -337,7 +337,7 @@ pub fn rasterize<O: FnMut(u32, u32, f32)>(lines: &[Line], curves: &[Curve],
                     }
                 }
                 //output
-                output(x, y, pixel_value);
+                output(x, y, pixel_value.abs());
                 acc += pixel_acc;
                 // remove deactivated segments
                 for k in lines_to_remove.drain(..) {
@@ -350,7 +350,7 @@ pub fn rasterize<O: FnMut(u32, u32, f32)>(lines: &[Line], curves: &[Curve],
             }
             // fill remaining pixels
             for x in x..width {
-                output(x, y, acc);
+                output(x, y, acc.abs());
             }
         }
         y += 1;


### PR DESCRIPTION
The change here is simply to call `.abs()` on values before sending them to output. It doesn't seem like having negative values is ever what any consumer expects or is prepared to handle.

I'm not at all sure this is the best solution for what's happening, but it does fix the bug I was having.

See #37 for the issue this is addressing.

If anyone can think of a better solution for this, or a way to fix the underlying algorithm rather than just laying an absolute value on top of it, that would be greatly appreciated! This is a hacky fix from someone who doesn't know much low-level graphics programming.