### PR TITLE
Add a simple new `image` example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+image_example.png

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ linked-hash-map = "0.5"
 [dev-dependencies]
 glium = "0.17"
 unicode-normalization = "0.1"
+image = "0.16.0"
 
 [features]
 # Compiles benchmark code, to be avoided normally as this currently requires nightly rust

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -24,10 +24,10 @@ fn main() {
     // Use a dark red colour
     let colour = (150, 0, 0);
 
-    // The starting position of the glyphs (top left corner)
+    // The starting positioning of the glyphs (top left corner)
     let start = point(20.0, 50.0);
 
-    // Loop through the glpyhs in the text, positing each one on a line
+    // Loop through the glyphs in the text, positing each one on a line
     for glyph in font.layout(text, scale, start) {
         if let Some(bounding_box) = glyph.pixel_bounding_box() {
             // Draw the glyph into the image per-pixel by using the draw closure

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -1,0 +1,46 @@
+extern crate rusttype;
+extern crate image;
+
+use rusttype::{FontCollection, Scale, point};
+use image::{Rgba, DynamicImage};
+
+fn main() {
+    // Load the font
+    let font_data = include_bytes!("../fonts/wqy-microhei/WenQuanYiMicroHei.ttf");
+    let collection = FontCollection::from_bytes(font_data as &[u8]);
+    // This only succeeds if collection consists of one font
+    let font = collection.into_font().unwrap();
+
+    // Create a new rgba image
+    let mut image = DynamicImage::new_rgba8(500, 100).to_rgba();
+
+    // The font size to use
+    let size = 32.0;
+    let scale = Scale {x: size, y: size};
+
+    // The text to render
+    let text = "This is RustType rendered into a png!";
+
+    // Use a dark red colour
+    let colour = (150, 0, 0);
+
+    // The starting position of the glyphs (top left corner)
+    let start = point(20.0, 50.0);
+
+    // Loop through the glpyhs in the text, positing each one on a line
+    for glyph in font.layout(text, scale, start) {
+        if let Some(bounding_box) = glyph.pixel_bounding_box() {
+            // Draw the glyph into the image per-pixel by using the draw closure
+            glyph.draw(|x, y, v| image.put_pixel(
+                // Offset the position by the glyph bounding box
+                x + bounding_box.min.x as u32,
+                y + bounding_box.min.y as u32,
+                // Turn the coverage into an alpha value
+                Rgba {data: [colour.0, colour.1, colour.2, (v * 255.0) as u8]}
+            ));
+        }
+    }
+
+    // Save the image to a png file
+    image.save("image_example.png").unwrap();
+}


### PR DESCRIPTION
Hi, personally, I found the `simple` example to be a _little too_ complicated for my tastes (and rendering to a terminal was a bit wierd), so I went and created this simple example that renders out to an png image using the [`image`](https://crates.io/crates/image) crate.

This is the image this example produces: 
![image_example](https://user-images.githubusercontent.com/13566135/31062972-631108e4-a78b-11e7-90db-99b7ee570315.png)

Feedback welcome!


