### PR TITLE
Fix gpu_cache PGlyphSpec Ord,Eq implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ exclude = ["/fonts/**"]
 arrayvec = "0.4"
 stb_truetype = "0.2"
 linked-hash-map = "0.5"
+ordered-float = "0.5"
 
 [dev-dependencies]
 glium = "0.17"

--- a/src/gpu_cache.rs
+++ b/src/gpu_cache.rs
@@ -27,26 +27,39 @@ use ::{PositionedGlyph, Rect, Scale, GlyphId, Vector};
 use std::collections::{HashMap, HashSet, BTreeMap};
 use std::collections::Bound::{Included, Unbounded};
 use linked_hash_map::LinkedHashMap;
+use ordered_float::OrderedFloat;
+use std::cmp::{PartialEq, Eq, Ord, PartialOrd, Ordering};
 
-#[derive(PartialEq, PartialOrd, Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 struct PGlyphSpec {
     font_id: usize,
     glyph_id: GlyphId,
     scale: Scale,
-    offset: Vector<f32>
+    offset: Vector<f32>,
 }
 
-impl ::std::cmp::Eq for PGlyphSpec {}
+impl PartialEq for PGlyphSpec {
+    fn eq(&self, other: &PGlyphSpec) -> bool {
+        self.to_orderable() == other.to_orderable()
+    }
+}
 
-impl ::std::cmp::Ord for PGlyphSpec {
-    fn cmp(&self, other: &PGlyphSpec) -> ::std::cmp::Ordering {
-        self.partial_cmp(other).unwrap()
+impl Eq for PGlyphSpec {}
+
+impl PartialOrd for PGlyphSpec {
+    fn partial_cmp(&self, other: &PGlyphSpec) -> Option<Ordering> {
+        self.to_orderable().partial_cmp(&other.to_orderable())
+    }
+}
+
+impl Ord for PGlyphSpec {
+    fn cmp(&self, other: &PGlyphSpec) -> Ordering {
+        self.to_orderable().cmp(&other.to_orderable())
     }
 }
 
 impl PGlyphSpec {
-    /// Returns if this cached glyph can be considered to match another
-    /// at input tolerances
+    /// Returns if this cached glyph can be considered to match another at input tolerances
     fn matches(&self, other: &PGlyphSpec, scale_tolerance: f32, position_tolerance: f32)
         -> bool
     {
@@ -56,6 +69,26 @@ impl PGlyphSpec {
             (self.scale.y - other.scale.y).abs() < scale_tolerance &&
             (self.offset.x - other.offset.x).abs() < position_tolerance &&
             (self.offset.y - other.offset.y).abs() < position_tolerance
+    }
+
+    /// Returns a data view that is implicitly equal-able/hash-able/orderable
+    fn to_orderable(&self) -> (
+        usize,
+        GlyphId,
+        OrderedFloat<f32>,
+        OrderedFloat<f32>,
+        OrderedFloat<f32>,
+        OrderedFloat<f32>,
+    ) {
+        let PGlyphSpec { font_id, glyph_id, scale, offset } = *self;
+        (
+            font_id,
+            glyph_id,
+            OrderedFloat(scale.x),
+            OrderedFloat(scale.y),
+            OrderedFloat(offset.x),
+            OrderedFloat(offset.y),
+        )
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,7 @@ extern crate unicode_normalization;
 extern crate arrayvec;
 extern crate stb_truetype;
 extern crate linked_hash_map;
+extern crate ordered_float;
 
 mod geometry;
 mod rasterizer;


### PR DESCRIPTION
Fix rare glyph ordering panic in gpu cache code caused by partial_cmp unwrap.
I used crate `ordered-float` to provide `Ord` implementations for floats, any other f32 -> Ord functionality would do too.

It's worth noting I produced this panic in the wild, so this isn't a theoretical or pedantic fix.

...It also seems this is an ~~accidental~~ totally deliberate optimisation. When checking for regressions I noticed a speedup in benchmarks. The **p1** results are a nice speedup outside of the benchmark error. 

```
 name                                                    control.stdout ns/iter  change.stdout ns/iter  diff ns/iter   diff %  speedup 
 gpu_cache::cache_bench_tests::cache_bench_tolerance_1   3,317,397               3,096,244                  -221,153   -6.67%   x 1.07 
 gpu_cache::cache_bench_tests::cache_bench_tolerance_p1  6,931,439               5,391,674                -1,539,765  -22.21%   x 1.29 
```