### PR TITLE
Fix `shape_with_offset` method to correctly return multiple contours

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -616,7 +616,7 @@ impl<'a> ScaledGlyph<'a> {
                 let end = point(v.x as f32 * self.scale.x + offset.x,
                                 v.y as f32 * self.scale.y + offset.y);
                 match v.vertex_type() {
-                    VertexType::MoveTo if result.len() != 0 => {
+                    VertexType::MoveTo if current.len() != 0 => {
                         result.push(Contour {
                             segments: replace(&mut current, Vec::new())
                         })


### PR DESCRIPTION
Shape was calculated incorrectly as `MoveTo` instructions were always ignored. Condition `result.len() != 0` is always false so new contour would never be started. For example for the letter 'A' you would expect two contours - one for the letter itself and one for the hole, but only one unified contour was returned. This PR fixes this.