### PR TITLE
Add support for unscaled fonts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,12 +186,12 @@ enum GlyphInner<'a> {
 }
 
 #[derive(Debug)]
-struct SharedGlyphData {
-    id: u32,
-    extents: Option<Rect<i32>>,
-    scale_for_1_pixel: f32,
-    unit_h_metrics: HMetrics,
-    shape: Option<Vec<tt::Vertex>>
+pub struct SharedGlyphData {
+    pub id: u32,
+    pub extents: Option<Rect<i32>>,
+    pub scale_for_1_pixel: f32,
+    pub unit_h_metrics: HMetrics,
+    pub shape: Option<Vec<tt::Vertex>>
 }
 /// The "horizontal metrics" of a glyph. This is useful for calculating the horizontal offset of a glyph
 /// from the previous one in a string when laying a string out horizontally.
@@ -520,6 +520,14 @@ impl<'a> Glyph<'a> {
                 shape: font.info.get_glyph_shape(id)
             }))),
             GlyphInner::Shared(ref data) => Glyph::new(GlyphInner::Shared(data.clone()))
+        }
+    }
+    /// Get the data from this glyph (such as width, extents, vertices, etc.).
+    /// Only possible if the glyph is a shared glyph.
+    pub fn get_data(&self) -> Option<Arc<SharedGlyphData>> {
+        match self.inner {
+            GlyphInner::Proxy(_, _) => None,
+            GlyphInner::Shared(ref s) => Some(s.clone())
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,6 +214,29 @@ pub struct VMetrics {
     /// course only a guideline given by the font's designers.
     pub line_gap: f32
 }
+
+impl From<tt::VMetrics> for VMetrics {
+    fn from(vm: tt::VMetrics) -> Self {
+        Self {
+            ascent: vm.ascent as f32,
+            descent: vm.descent as f32,
+            line_gap: vm.line_gap as f32,
+        }
+    }
+}
+
+impl ::std::ops::Mul<f32> for VMetrics {
+    type Output = VMetrics;
+
+    fn mul(self, rhs: f32) -> Self {
+        Self {
+            ascent: self.ascent * rhs,
+            descent: self.descent * rhs,
+            line_gap: self.line_gap * rhs,
+        }
+    }
+}
+
 /// A glyph augmented with scaling information. You can query such a glyph for information that depends
 /// on the scale of the glyph.
 #[derive(Clone)]
@@ -324,11 +347,13 @@ impl<'a> Font<'a> {
     pub fn v_metrics(&self, scale: Scale) -> VMetrics {
         let vm = self.info.get_v_metrics();
         let scale = self.info.scale_for_pixel_height(scale.y);
-        VMetrics {
-            ascent: vm.ascent as f32 * scale,
-            descent: vm.descent as f32 * scale,
-            line_gap: vm.line_gap as f32 * scale
-        }
+        VMetrics::from(vm) * scale
+    }
+
+    /// Get the unscaled VMetrics for this font, shared by all glyphs.
+    /// See `VMetrics` for more detail.
+    pub fn v_metrics_unscaled(&self) -> VMetrics {
+        VMetrics::from(self.info.get_v_metrics())
     }
 
     /// The number of glyphs present in this font. Glyph identifiers for this font will always be in the range


### PR DESCRIPTION
For https://github.com/fschutt/printpdf I would like to use rusttype. However, the problem is that in PDFs, you need to embed unscaled fonts. For this you need to embed a table where the vertical metrics of each Unicode character are listed. PDFs need the **unscaled** metrics. I referenced this problem shortly in https://github.com/fschutt/printpdf/issues/1.

Now I don't know if / how https://github.com/redox-os/stb_truetype-rs/pull/9 is of importance (because when I originally made PR https://github.com/redox-os/rusttype/pull/46 I needed to fix some other issues in order to get it working. However, these fixes (to stb_truetype) have nothing to do with rusttype itself and people could go ahead and use the new `v_metrics_unscaled` function independent of the that PR.

The reason I want this is because right now, only freetype allows me to get the raw, unscaled vertical metrics of glyphs. This causes problems when building for Windows and I'd like to get away from freetype as much as I can. However, I need to reliably be able to get the vertical metrics for this. Now that `stb_truetype` has been transferred, there may be more hope for this to actually work than a few months ago.