### PR TITLE
Exposed units_per_em function in rusttype

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -356,6 +356,11 @@ impl<'a> Font<'a> {
         VMetrics::from(self.info.get_v_metrics())
     }
 
+    /// Returns the units per EM square of this font
+    pub fn units_per_em(&self) -> u16 {
+        self.info.units_per_em()
+    }
+
     /// The number of glyphs present in this font. Glyph identifiers for this font will always be in the range
     /// `0..self.glyph_count()`
     pub fn glyph_count(&self) -> usize {


### PR DESCRIPTION
Closes https://github.com/redox-os/rusttype/issues/79

NOTE: This will not yet compile, https://github.com/redox-os/stb_truetype-rs/pull/14 has to be merged previously + the stb_truetype version has to be updated! If this is merged, please release a new version on crates.io, so I can update my dependencies and depend on it from crates.io. 