### PR TITLE
Add an entry for `image` example in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,4 +41,7 @@ name = "gpu_cache"
 required-features = ["gpu_cache"]
 
 [[example]]
+name = "image"
+
+[[example]]
 name = "simple"


### PR DESCRIPTION
Examples should be explicitly listed because of #17, but `image` example
added by #62 was not described in Cargo.toml.