### PR TITLE
Add gpu_cache bench feature requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
-##0.4.0
+## 0.4.0
 
 * Add more debugging features
 * Add support for unscaled fonts
 * Improve performance
 * Make gpu_cache optional
 
-##0.3.0
+## 0.3.0
 
 * Transfer to redox-os organization, merge a number of pull requests
 
-##0.2.1
+## 0.2.1
 
 * Made the API more convenient (courtesy of @mitchmindtree, @I1048576).
 * Fixes for the examples (@I1048576)
@@ -21,14 +21,14 @@
 * Made font data management more flexible.
 * Made the interface for font scales simpler.
 
-##0.1.2
+## 0.1.2
 
 Fixed issue #8
 
-##0.1.1
+## 0.1.1
 
 Fixed issue #7
 
-#0.1
+# 0.1
 
 Initial release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,13 +30,13 @@ linked-hash-map = { version = "0.5", optional = true }
 ordered-float = "0.5"
 
 [dev-dependencies]
-glium = "0.17"
+glium = "0.20"
 unicode-normalization = "0.1"
-image = "0.16.0"
+image = "0.18"
 
 [features]
 # Compiles benchmark code, to be avoided normally as this currently requires nightly rust
-bench = []
+bench = ["gpu_cache"]
 gpu_cache = ["linked-hash-map"]
 
 [[example]]

--- a/examples/gpu_cache.rs
+++ b/examples/gpu_cache.rs
@@ -121,7 +121,7 @@ Feel free to type out some text, and delete it with Backspace. You can also try 
     loop {
         let (width, dpi_factor) = {
             let window = display.gl_window();
-            (window.get_inner_size_pixels().unwrap().0, window.hidpi_factor())
+            (window.get_inner_size().unwrap().0, window.hidpi_factor())
         };
 
         let mut finished = false;


### PR DESCRIPTION
Minor updates outside of the main source code
* Add gpu_cache feature requirement to bench so `cargo +nightly bench --features bench` works
* Updated dev-dependencies
* Fix deprecated `get_inner_size_pixels()` winit usage in gpu_cache example
* Fix changelog h* markdown usage _(won't render properly in some markdown parsers, ie github's)_