### PR TITLE
Bumps the patch level of stb_truetype dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ features = ["gpu_cache"]
 
 [dependencies]
 arrayvec = "0.4"
-stb_truetype = "0.2"
+stb_truetype = "0.2.2"
 linked-hash-map = { version = "0.5", optional = true }
 ordered-float = "0.5"
 


### PR DESCRIPTION
Commit 2989ad8 exposed the `units_per_em` function from the stb_truetype
crate, but did not update the Cargo.toml to reflect that it was added
in the 0.2.2 patch of stb_truetype.

Projects already using a "0.2" semver in their Cargo.toml would not
bother to update from 0.2.0 or 0.2.1, and results in a compile error.