### PR TITLE
Use fnv hashing for gpu_cache small keys maps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,9 @@ features = ["gpu_cache"]
 [dependencies]
 arrayvec = "0.4"
 stb_truetype = "0.2.2"
-linked-hash-map = { version = "0.5", optional = true }
 ordered-float = "0.5"
+linked-hash-map = { version = "0.5", optional = true }
+fnv = { version = "1", optional = true }
 
 [dev-dependencies]
 glium = "0.20"
@@ -37,7 +38,7 @@ image = "0.18"
 [features]
 # Compiles benchmark code, to be avoided normally as this currently requires nightly rust
 bench = ["gpu_cache"]
-gpu_cache = ["linked-hash-map"]
+gpu_cache = ["linked-hash-map", "fnv"]
 
 [[example]]
 name = "gpu_cache"

--- a/src/gpu_cache.rs
+++ b/src/gpu_cache.rs
@@ -27,11 +27,13 @@
 //! each glyph. For a concrete use case see the `gpu_cache` example.
 
 extern crate linked_hash_map;
+extern crate fnv;
 
 use ::{PositionedGlyph, Rect, Scale, GlyphId, Vector};
 use std::collections::{HashMap, HashSet, BTreeMap};
 use std::collections::Bound::{Included, Unbounded};
 use self::linked_hash_map::LinkedHashMap;
+use self::fnv::FnvBuildHasher;
 use ordered_float::OrderedFloat;
 use std::cmp::{PartialEq, Eq, Ord, PartialOrd, Ordering};
 use std::error;
@@ -163,12 +165,12 @@ pub struct Cache<'font> {
     position_tolerance: f32,
     width: u32,
     height: u32,
-    rows: LinkedHashMap<u32, Row>,
-    space_start_for_end: HashMap<u32, u32>,
-    space_end_for_start: HashMap<u32, u32>,
+    rows: LinkedHashMap<u32, Row, FnvBuildHasher>,
+    space_start_for_end: HashMap<u32, u32, FnvBuildHasher>,
+    space_end_for_start: HashMap<u32, u32, FnvBuildHasher>,
     queue: Vec<(usize, PositionedGlyph<'font>)>,
     queue_retry: bool,
-    all_glyphs: HashMap<(FontId, GlyphId), BTreeMap<PGlyphSpec, (u32, u32)>>,
+    all_glyphs: HashMap<(FontId, GlyphId), BTreeMap<PGlyphSpec, (u32, u32)>, FnvBuildHasher>,
 }
 
 /// Returned from `Cache::rect_for`.
@@ -264,12 +266,12 @@ impl<'font> Cache<'font> {
             position_tolerance: position_tolerance,
             width: width,
             height: height,
-            rows: LinkedHashMap::new(),
-            space_start_for_end: {let mut m = HashMap::new(); m.insert(height, 0); m},
-            space_end_for_start: {let mut m = HashMap::new(); m.insert(0, height); m},
+            rows: LinkedHashMap::default(),
+            space_start_for_end: {let mut m = HashMap::default(); m.insert(height, 0); m},
+            space_end_for_start: {let mut m = HashMap::default(); m.insert(0, height); m},
             queue: Vec::new(),
             queue_retry: false,
-            all_glyphs: HashMap::new()
+            all_glyphs: HashMap::default(),
         }
     }
 


### PR DESCRIPTION
Switching to fnv hashing for the small key maps within `gpu_cache::Cache` yields a modest performance boost. No API breakage either.

_Bench comparison_
```
name                                                    control ns/iter  change ns/iter  diff ns/iter   diff %  speedup 
gpu_cache::cache_bench_tests::cache_bench_tolerance_1   2,222,202        1,901,643           -320,559  -14.43%   x 1.17 
gpu_cache::cache_bench_tests::cache_bench_tolerance_p1  4,374,605        4,114,195           -260,410   -5.95%   x 1.06
```