### PR TITLE
Replace CodepointOrGlyphId enum with IntoGlyphId trait.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## master
 
+## 0.5.0
+
+* Let functions like `Font::glyph` and `Font::pair_kerning` work with both
+  characters and glyph ids by having them accept any type that implements the
+  new `IntoGlyphId` trait. This replaces the `CodepointOrGlyph` enum, which
+  didn't seem widely used.
+
 ## 0.4.3
 
 * Improve gpu_cache performance

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusttype"
-version = "0.4.3"
+version = "0.5.0"
 authors = [
     "Dylan Ede <dylanede@googlemail.com>",
     "Jeremy Soller <jackpot51@gmail.com>"


### PR DESCRIPTION
This implements the change proposed in #89. I've tested it against the ten most-downloaded crates that depend on rusttype (listed below), and none of them required source code changes.

```
Lattice
conrod
font-atlas
gfx-glyph
ggez
imageproc
orbfont
piston2d-graphics --features=glyph_cache_rusttype
radiant-rs
waterfall
```