### PR TITLE
Make `Font::glyph` return `Glyph`, not `Option<Glyph>`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   new `IntoGlyphId` trait. This replaces the `CodepointOrGlyph` enum, which
   didn't seem widely used.
 
+* Make `Font::glyph` always return a `Glyph`, not `Option<Glyph>`. Passing a
+  `char` the font doesn't cover returns a `.notdef` glyph (id 0), as it did
+  before. Passing an invalid glyph id now panics, like a bad array index: glyph
+  ids should only be used to index the font they were looked up for.
+
 ## 0.4.3
 
 * Improve gpu_cache performance

--- a/examples/gpu_cache.rs
+++ b/examples/gpu_cache.rs
@@ -32,11 +32,7 @@ fn layout_paragraph<'a>(
             }
             continue;
         }
-        let base_glyph = if let Some(glyph) = font.glyph(c) {
-            glyph
-        } else {
-            continue;
-        };
+        let base_glyph = font.glyph(c);
         if let Some(id) = last_glyph_id.take() {
             caret.x += font.pair_kerning(scale, id, base_glyph.id());
         }

--- a/src/gpu_cache.rs
+++ b/src/gpu_cache.rs
@@ -781,7 +781,7 @@ fn need_to_check_whole_cache() {
         .into_font()
         .unwrap();
 
-    let glyph = font.glyph('l').unwrap();
+    let glyph = font.glyph('l');
 
     let small = glyph.clone().scaled(Scale::uniform(10.0));
     let large = glyph.clone().scaled(Scale::uniform(10.05));
@@ -899,11 +899,7 @@ mod cache_bench_tests {
                 }
                 continue;
             }
-            let base_glyph = if let Some(glyph) = font.glyph(c) {
-                glyph
-            } else {
-                continue;
-            };
+            let base_glyph = font.glyph(c);
             if let Some(id) = last_glyph_id.take() {
                 caret.x += font.pair_kerning(scale, id, base_glyph.id());
             }


### PR DESCRIPTION
This patch implements the change suggested in issue #96. The impact on downstream crates is described in that issue.

This change would require a version bump.
