### PR TITLE
Fix clippy complaints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ features = ["gpu_cache"]
 arrayvec = "0.4"
 stb_truetype = "0.2.2"
 ordered-float = "0.5"
+approx = "0.1"
 linked-hash-map = { version = "0.5", optional = true }
 fnv = { version = "1", optional = true }
 

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -327,25 +327,22 @@ pub fn solve_quadratic_real(a: f32, b: f32, c: f32) -> RealQuadraticSolution {
         }
     } else if discriminant < 0.0 {
         RealQuadraticSolution::None
-    } else {
-        // discriminant == 0.0
-        if b == 0.0 {
-            if a == 0.0 {
-                if c == 0.0 {
-                    RealQuadraticSolution::All
-                } else {
-                    RealQuadraticSolution::None
-                }
+    } else if b == 0.0 {
+        if a == 0.0 {
+            if c == 0.0 {
+                RealQuadraticSolution::All
             } else {
-                RealQuadraticSolution::Touch(0.0)
+                RealQuadraticSolution::None
             }
         } else {
-            RealQuadraticSolution::Touch(2.0 * c / -b)
+            RealQuadraticSolution::Touch(0.0)
         }
+    } else {
+        RealQuadraticSolution::Touch(2.0 * c / -b)
     }
 }
 
 #[test]
 fn quadratic_test() {
-    solve_quadratic_real(-0.0000001, -2.0, 10.0);
+    solve_quadratic_real(-0.000_000_1, -2.0, 10.0);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,12 +95,17 @@
 //!   particular Unicode code point. This will have its own identifying number
 //!   unique to the font, its ID.
 
+#![allow(unknown_lints)]
+#![warn(clippy)]
+#![allow(cyclomatic_complexity, doc_markdown, cast_lossless, many_single_char_names)]
 #![cfg_attr(feature = "bench", feature(test))]
 #[cfg(feature = "bench")]
 extern crate test;
 #[cfg(test)]
 extern crate unicode_normalization;
 
+#[macro_use]
+extern crate approx;
 extern crate arrayvec;
 extern crate ordered_float;
 extern crate stb_truetype;
@@ -711,7 +716,7 @@ impl<'a> ScaledGlyph<'a> {
                     v.y as f32 * self.scale.y + offset.y,
                 );
                 match v.vertex_type() {
-                    VertexType::MoveTo if current.len() != 0 => result.push(Contour {
+                    VertexType::MoveTo if !current.is_empty() => result.push(Contour {
                         segments: replace(&mut current, Vec::new()),
                     }),
                     VertexType::LineTo => current.push(Segment::Line(Line { p: [last, end] })),
@@ -728,7 +733,7 @@ impl<'a> ScaledGlyph<'a> {
                 }
                 last = end;
             }
-            if current.len() > 0 {
+            if !current.is_empty() {
                 result.push(Contour {
                     segments: replace(&mut current, Vec::new()),
                 });
@@ -839,9 +844,9 @@ impl<'a> PositionedGlyph<'a> {
         use stb_truetype::VertexType;
         let shape = match self.sg.g.inner {
             GlyphInner::Proxy(ref font, id) => {
-                font.info.get_glyph_shape(id).unwrap_or_else(|| Vec::new())
+                font.info.get_glyph_shape(id).unwrap_or_else(Vec::new)
             }
-            GlyphInner::Shared(ref data) => data.shape.clone().unwrap_or_else(|| Vec::new()),
+            GlyphInner::Shared(ref data) => data.shape.clone().unwrap_or_else(Vec::new),
         };
         let bb = if let Some(bb) = self.bb.as_ref() {
             bb


### PR DESCRIPTION
This pr addresses all current clippy warnings, in particular adds `approx` crate to deal with float equality. Using our current benchmarks the float equality change seems to have no effect on performance.