### PR TITLE
Add Font::from_bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Introduce `rusttype::Error`, which implements `std::error::Error`, `Debug` and
   `Display`, and can be converted to `std::io::Error`.
 * Use `Result<_, rusttype::Error>` to report failures in FontCollection, Font and associated iterators.
+* Add `Font::from_bytes` method similar to `FontCollection::from_bytes` for 1 font collections.
 * Improve gpu_cache performance ~2-6%
 
 ## 0.4.3

--- a/examples/gpu_cache.rs
+++ b/examples/gpu_cache.rs
@@ -5,7 +5,7 @@ extern crate rusttype;
 extern crate unicode_normalization;
 
 use glium::{glutin, Surface};
-use rusttype::{point, vector, Font, FontCollection, PositionedGlyph, Rect, Scale};
+use rusttype::{point, vector, Font, PositionedGlyph, Rect, Scale};
 use rusttype::gpu_cache::Cache;
 use std::borrow::Cow;
 
@@ -53,10 +53,7 @@ fn layout_paragraph<'a>(
 
 fn main() {
     let font_data = include_bytes!("../fonts/wqy-microhei/WenQuanYiMicroHei.ttf");
-    let font = FontCollection::from_bytes(font_data as &[u8])
-        .unwrap()
-        .into_font()
-        .unwrap();
+    let font = Font::from_bytes(font_data as &[u8]).unwrap();
 
     let window = glutin::WindowBuilder::new()
         .with_dimensions(512, 512)

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -2,17 +2,14 @@ extern crate image;
 extern crate rusttype;
 
 use image::{DynamicImage, Rgba};
-use rusttype::{point, FontCollection, Scale};
+use rusttype::{point, Font, Scale};
 
 fn main() {
     // Load the font
     let font_data = include_bytes!("../fonts/wqy-microhei/WenQuanYiMicroHei.ttf");
-    let collection =
-        FontCollection::from_bytes(font_data as &[u8]).expect("Error building FontCollection");
     // This only succeeds if collection consists of one font
-    let font = collection
-        .into_font()
-        .expect("Error converting FontCollection to Font");
+    let font =
+        Font::from_bytes(font_data as &[u8]).expect("Error constructing Font");
 
     // Create a new rgba image
     let mut image = DynamicImage::new_rgba8(500, 100).to_rgba();

--- a/src/gpu_cache.rs
+++ b/src/gpu_cache.rs
@@ -782,7 +782,7 @@ fn need_to_check_whole_cache() {
 #[cfg(test)]
 mod cache_bench_tests {
     use super::*;
-    use {point, Font, FontCollection, Scale};
+    use {point, Font, Scale};
 
     lazy_static! {
         static ref FONTS: Vec<Font<'static>> = vec![
@@ -790,7 +790,7 @@ mod cache_bench_tests {
             include_bytes!("../fonts/dejavu/DejaVuSansMono.ttf") as &[u8],
             include_bytes!("../fonts/opensans/OpenSans-Italic.ttf") as &[u8],
         ].into_iter()
-            .map(|bytes| FontCollection::from_bytes(bytes).and_then(|c| c.into_font()).unwrap())
+            .map(|bytes| Font::from_bytes(bytes).unwrap())
             .collect();
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,6 +403,12 @@ impl<'a> Iterator for IntoFontsIter<'a> {
     }
 }
 impl<'a> Font<'a> {
+    /// Constructs a font from an array of bytes, this is a shortcut for
+    /// `FontCollection::from_bytes` for collections comprised of a single font.
+    pub fn from_bytes<B: Into<SharedBytes<'a>>>(bytes: B) -> Result<Font<'a>, Error> {
+        FontCollection::from_bytes(bytes).and_then(|c| c.into_font())
+    }
+
     /// The "vertical metrics" for this font at a given scale. These metrics are
     /// shared by all of the glyphs in the font. See `VMetrics` for more detail.
     pub fn v_metrics(&self, scale: Scale) -> VMetrics {


### PR DESCRIPTION
This eases quite a common case; a single font collection. Works quite naturally with #100 error additions.