### PR TITLE
Pad gpu cache glyphs II

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## master
 
-* Inlining performance improvements.
 * Add gpu cache glyph padding option to fix texture bleeding from other
   glyphs when using interpolated texture coordinates near edges. Use
   `CacheBuilder` to construct a `Cache` that makes use of padding.
+* Inlining performance improvements.
 
 ## 0.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## master
 
 * Inlining performance improvements.
-* Add gpu cache glyph padding to fix texture bleeding from other glyphs when
-  using interpolated texture coordinates near edges.
+* Add gpu cache glyph padding option to fix texture bleeding from other
+  glyphs when using interpolated texture coordinates near edges. Use
+  `CacheBuilder` to construct a `Cache` that makes use of padding.
 
 ## 0.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 ## master
 
 * Inlining performance improvements.
+* Add gpu cache glyph padding to fix texture bleeding from other glyphs when
+  using interpolated texture coordinates near edges.
 
 ## 0.5.1
 
-* Fix tree removal on row clear
+* Fix tree removal on row clear (gpu_cache).
 
 ## 0.5.0
 
@@ -18,8 +20,10 @@
   ids should only be used to index the font they were looked up for.
 * Introduce `rusttype::Error`, which implements `std::error::Error`, `Debug` and
   `Display`, and can be converted to `std::io::Error`.
-* Use `Result<_, rusttype::Error>` to report failures in FontCollection, Font and associated iterators.
-* Add `Font::from_bytes` method similar to `FontCollection::from_bytes` for 1 font collections.
+* Use `Result<_, rusttype::Error>` to report failures in FontCollection, Font
+  and associated iterators.
+* Add `Font::from_bytes` method similar to `FontCollection::from_bytes` for 1
+  font collections.
 * Improve gpu_cache performance ~2-6%
 
 ## 0.4.3

--- a/examples/gpu_cache.rs
+++ b/examples/gpu_cache.rs
@@ -6,7 +6,7 @@ extern crate unicode_normalization;
 
 use glium::{glutin, Surface};
 use rusttype::{point, vector, Font, PositionedGlyph, Rect, Scale};
-use rusttype::gpu_cache::Cache;
+use rusttype::gpu_cache::CacheBuilder;
 use std::borrow::Cow;
 
 fn layout_paragraph<'a>(
@@ -65,7 +65,11 @@ fn main() {
     let dpi_factor = display.gl_window().hidpi_factor();
 
     let (cache_width, cache_height) = (512 * dpi_factor as u32, 512 * dpi_factor as u32);
-    let mut cache = Cache::new(cache_width, cache_height, 0.1, 0.1);
+    let mut cache = CacheBuilder {
+        width: cache_width,
+        height: cache_height,
+        ..CacheBuilder::default()
+    }.build();
 
     let program = program!(
         &display,

--- a/src/gpu_cache.rs
+++ b/src/gpu_cache.rs
@@ -955,8 +955,10 @@ mod cache_bench_tests {
         let font_id = 0;
         let glyphs = test_glyphs(&FONTS[font_id], TEST_STR);
         let mut cache = CacheBuilder{
-            width: 768,
-            height: 768,
+            width: 1024,
+            height: 1024,
+            scale_tolerance: 0.1,
+            position_tolerance: 0.1,
             ..CacheBuilder::default()
         }.build();
 
@@ -985,8 +987,10 @@ mod cache_bench_tests {
         let font_id = 0;
         let glyphs = test_glyphs(&FONTS[font_id], TEST_STR);
         let mut cache = CacheBuilder{
-            width: 768,
-            height: 768,
+            width: 1024,
+            height: 1024,
+            scale_tolerance: 0.1,
+            position_tolerance: 1.0,
             ..CacheBuilder::default()
         }.build();
 
@@ -1027,8 +1031,10 @@ mod cache_bench_tests {
             .map(|(id, font)| (id, test_glyphs(font, string)))
             .collect();
         let mut cache = CacheBuilder{
-            width: 768,
-            height: 768,
+            width: 1024,
+            height: 1024,
+            scale_tolerance: 0.1,
+            position_tolerance: 0.1,
             ..CacheBuilder::default()
         }.build();
 


### PR DESCRIPTION
This pr addresses the texture bleeding issues from other glyphs in the gpu texture. This happens after some sort of transforms causes the texture lookups to be interpolated by the shader, introducing enough error for the alpha values to be potentially affected at the edges. See #28, https://github.com/alexheretic/gfx-glyph/issues/20.

The problem is tackled by packing all glyphs with a single extra zero-alpha pixel ~on the bottom & right. This increases glyph texture size by +1 vertical and +1 horizontal pixels~ on all sides, increases glyph texture usage height/width by +2 pixels. Compared with #36 this change preserves API compatibility and introduces `CacheBuilder` to use glyph padding, it also includes "unpadding" logic in `rect_for` making padding invisible to rendering.

The change is not breaking. You need to change usage from `Cache::new` -> `CacheBuilder` to make use of padding. 

Benchmark movement is within 1% of control.

closes #36
fixes #28