### PR TITLE
Inline point(x, y) & vector(x, y)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master
 
+* Inlining performance improvements.
+
 ## 0.5.1
 
 * Fix tree removal on row clear

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -31,10 +31,12 @@ pub struct Vector<N> {
     pub y: N,
 }
 /// A convenience function for generating `Point`s.
+#[inline]
 pub fn point<N>(x: N, y: N) -> Point<N> {
     Point { x, y }
 }
 /// A convenience function for generating `Vector`s.
+#[inline]
 pub fn vector<N>(x: N, y: N) -> Vector<N> {
     Vector { x, y }
 }


### PR DESCRIPTION
Adding a inline hint for `point(x,y)` & `vector(x,y)` yields a surprising difference to the gpu_cache benchmarks.
```
name                                                              control ns/iter  change ns/iter  diff ns/iter  diff %  speedup 
gpu_cache::cache_bench_tests::cache_bench_tolerance_1             1,820,219        1,828,535              8,316   0.46%   x 1.00 
gpu_cache::cache_bench_tests::cache_bench_tolerance_p1            4,310,574        3,901,391           -409,183  -9.49%   x 1.10 
gpu_cache::cache_bench_tests::cache_bench_tolerance_p1_multifont  3,781,790        3,500,211           -281,579  -7.45%   x 1.08 
```