### PR TITLE
Remove internal hashing in rasterizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## master
 
-* Use fnv for internal rasterizer hashing. Improves draw benchmark
-  performance by 9-65%.
+* Optimise rasterizer removing internal hashing. Improves draw benchmark
+  performance by 11-91%.
 
 ## 0.6.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ arrayvec = "0.4"
 stb_truetype = "0.2.2"
 ordered-float = "0.5"
 approx = "0.2"
-fnv = "1"
 linked-hash-map = { version = "0.5", optional = true }
+fnv = { version = "1", optional = true }
 
 [dev-dependencies]
 glium = "0.21"
@@ -42,7 +42,7 @@ blake2 = "0.7"
 [features]
 # Compiles benchmark code, to be avoided normally as this currently requires nightly rust
 bench = ["gpu_cache"]
-gpu_cache = ["linked-hash-map"]
+gpu_cache = ["linked-hash-map", "fnv"]
 
 [[example]]
 name = "gpu_cache"

--- a/src/gpu_cache.rs
+++ b/src/gpu_cache.rs
@@ -38,10 +38,11 @@
 //! cache texture (e.g. due to high cache pressure), construct a new `Cache`
 //! and discard the old one.
 
+extern crate fnv;
 extern crate linked_hash_map;
 
+use self::fnv::{FnvBuildHasher, FnvHashMap};
 use self::linked_hash_map::LinkedHashMap;
-use fnv::{FnvBuildHasher, FnvHashMap};
 use std::collections::{HashMap, HashSet};
 use std::error;
 use std::fmt;
@@ -688,7 +689,8 @@ impl<'font> Cache<'font> {
             return Ok(None);
         }
 
-        let (row, index) = self.all_glyphs
+        let (row, index) = self
+            .all_glyphs
             .get(&self.lossy_info_for(font_id, glyph))
             .ok_or(CacheReadErr::GlyphNotCached)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -528,10 +528,12 @@ impl<'a> Font<'a> {
         A: IntoGlyphId,
         B: IntoGlyphId,
     {
-        let (first, second) = (self.glyph(first), self.glyph(second));
+        let first_id = first.into_glyph_id(self);
+        let second_id = second.into_glyph_id(self);
         let factor = self.info.scale_for_pixel_height(scale.y) * (scale.x / scale.y);
-        let kern = self.info
-            .get_glyph_kern_advance(first.id().0, second.id().0);
+        let kern = self
+            .info
+            .get_glyph_kern_advance(first_id.0, second_id.0);
         factor * kern as f32
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,6 @@ extern crate lazy_static;
 #[macro_use]
 extern crate approx;
 extern crate arrayvec;
-extern crate fnv;
 extern crate ordered_float;
 extern crate stb_truetype;
 


### PR DESCRIPTION
Along with the quick win hashing optimisation of #115 I noted

> I actually expect we can rasterize without any hashing...

A bit sooner than I thought I got a chance to look over the map usage, and indeed we can replace all rasterizer hash maps with vecs using ordered `swap_remove` calls and we get even better peformance.

Even faster than fnv hashing is **not hashing**.

This replaces the previous improvement with **11-91%** faster benchmark drawing since `0.6.0`.

```
name                                                       control ns/iter  change ns/iter  diff ns/iter   diff %  speedup 
draw_big_biohazard                                         908,156          820,894              -87,262   -9.61%   x 1.11 
draw_iota                                                  37,701           22,998               -14,703  -39.00%   x 1.64 
draw_w                                                     10,195           5,334                 -4,861  -47.68%   x 1.91 
gpu_cache::cache_bench_tests::bench_multi_font_population  12,339,345       8,499,095         -3,840,250  -31.12%   x 1.45
```

Also made a minor improvement to the kerning code to avoid glyph lookup & use the provided ids directly.