### PR TITLE
Improve lazy_static -> SharedBytes conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master
 
+* Add `From<&AsRef<[u8]>> for SharedBytes`.
+
 ## 0.6.1
 
 * Optimise rasterizer removing internal hashing. Improves draw benchmark

--- a/benches/draw.rs
+++ b/benches/draw.rs
@@ -10,11 +10,9 @@ use rusttype::*;
 
 lazy_static! {
     static ref DEJA_VU_MONO: Font<'static> =
-        Font::from_bytes(include_bytes!("../fonts/dejavu/DejaVuSansMono.ttf") as &[u8])
-            .expect("!DEJA_VU_MONO");
+        Font::from_bytes(include_bytes!("../fonts/dejavu/DejaVuSansMono.ttf") as &[u8]).unwrap();
     static ref OPEN_SANS_ITALIC: Font<'static> =
-        Font::from_bytes(include_bytes!("../fonts/opensans/OpenSans-Italic.ttf") as &[u8])
-            .expect("!DEJA_VU_MONO");
+        Font::from_bytes(include_bytes!("../fonts/opensans/OpenSans-Italic.ttf") as &[u8]).unwrap();
 }
 
 #[bench]

--- a/examples/gpu_cache.rs
+++ b/examples/gpu_cache.rs
@@ -5,8 +5,8 @@ extern crate rusttype;
 extern crate unicode_normalization;
 
 use glium::{glutin, Surface};
-use rusttype::{point, vector, Font, PositionedGlyph, Rect, Scale};
 use rusttype::gpu_cache::CacheBuilder;
+use rusttype::{point, vector, Font, PositionedGlyph, Rect, Scale};
 use std::borrow::Cow;
 
 fn layout_paragraph<'a>(

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -3,5 +3,3 @@ wrap_comments = true
 error_on_line_overflow = false
 use_field_init_shorthand = true
 condense_wildcard_suffixes = true
-reorder_imported_names = true
-reorder_imports = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,7 +206,9 @@ impl<'a, T: AsRef<[u8]>> From<&'a T> for SharedBytes<'a> {
 
 #[test]
 fn lazy_static_shared_bytes() {
-    lazy_static! { static ref BYTES: Vec<u8> = vec![0, 1, 2, 3]; }
+    lazy_static! {
+        static ref BYTES: Vec<u8> = vec![0, 1, 2, 3];
+    }
     let shared_bytes: SharedBytes<'static> = (&*BYTES).into();
     assert_eq!(&*shared_bytes, &[0, 1, 2, 3]);
 }
@@ -214,8 +216,9 @@ fn lazy_static_shared_bytes() {
 /// Represents a Unicode code point.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Codepoint(pub u32);
-/// Represents a glyph identifier for a particular font. This identifier will not necessarily
-/// correspond to the correct glyph in a font other than the one that it was obtained from.
+/// Represents a glyph identifier for a particular font. This identifier will
+/// not necessarily correspond to the correct glyph in a font other than the
+/// one that it was obtained from.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct GlyphId(pub u32);
 /// A single glyph of a font. this may either be a thin wrapper referring to the
@@ -573,9 +576,7 @@ impl<'a> Font<'a> {
         let first_id = first.into_glyph_id(self);
         let second_id = second.into_glyph_id(self);
         let factor = self.info.scale_for_pixel_height(scale.y) * (scale.x / scale.y);
-        let kern = self
-            .info
-            .get_glyph_kern_advance(first_id.0, second_id.0);
+        let kern = self.info.get_glyph_kern_advance(first_id.0, second_id.0);
         factor * kern as f32
     }
 }
@@ -735,7 +736,8 @@ impl<'a> ScaledGlyph<'a> {
     /// depend on the position of the glyph available.
     pub fn positioned(self, p: Point<f32>) -> PositionedGlyph<'a> {
         let bb = match self.g.inner {
-            GlyphInner::Proxy(ref font, id) => font.info
+            GlyphInner::Proxy(ref font, id) => font
+                .info
                 .get_glyph_bitmap_box_subpixel(id, self.scale.x, self.scale.y, p.x, p.y)
                 .map(|bb| Rect {
                     min: point(bb.x0, bb.y0),
@@ -989,8 +991,8 @@ pub enum Error {
     /// the collection doesn't contain that many fonts.
     CollectionIndexOutOfBounds,
 
-    /// The caller tried to convert a `FontCollection` into a font via `into_font`,
-    /// but the `FontCollection` contains more than one font.
+    /// The caller tried to convert a `FontCollection` into a font via
+    /// `into_font`, but the `FontCollection` contains more than one font.
     CollectionContainsMultipleFonts,
 }
 

--- a/src/rasterizer.rs
+++ b/src/rasterizer.rs
@@ -96,9 +96,9 @@ impl Iterator for CurveSliceIter {
     type Item = CurveIter;
     fn next(&mut self) -> Option<Self::Item> {
         use arrayvec::ArrayVec;
+        use geometry::solve_quadratic_real as solve;
         use geometry::Cut;
         use geometry::RealQuadraticSolution as RQS;
-        use geometry::solve_quadratic_real as solve;
         if self.i >= self.planes.count {
             return None;
         }
@@ -148,7 +148,9 @@ impl Iterator for CurveSliceIter {
                 // coincident with one plane
                 result.push(self.curve);
             }
-            (RQS::None, RQS::None) => if self.a == 0.0 && self.b == 0.0 && self.c_shift >= lower_d
+            (RQS::None, RQS::None) => if self.a == 0.0
+                && self.b == 0.0
+                && self.c_shift >= lower_d
                 && self.c_shift <= upper_d
             {
                 // parallel to planes, inbetween
@@ -217,7 +219,9 @@ pub fn rasterize<O: FnMut(u32, u32, f32)>(
     let mut scanline_curves = Vec::new();
     let mut curves_to_remove = Vec::new();
     while y < height
-        && (next_line != lines.len() || next_curve != curves.len() || !active_lines_y.is_empty()
+        && (next_line != lines.len()
+            || next_curve != curves.len()
+            || !active_lines_y.is_empty()
             || !active_curves_y.is_empty())
     {
         let lower = y as f32;
@@ -286,8 +290,10 @@ pub fn rasterize<O: FnMut(u32, u32, f32)>(
             active_lines_x.clear();
             active_curves_x.clear();
             while x < width
-                && (next_line != scanline_lines.len() || next_curve != scanline_curves.len()
-                    || !active_lines_x.is_empty() || !active_curves_x.is_empty())
+                && (next_line != scanline_lines.len()
+                    || next_curve != scanline_curves.len()
+                    || !active_lines_x.is_empty()
+                    || !active_curves_x.is_empty())
             {
                 let offset = vector(x as f32, y as f32);
                 let lower = x as f32;

--- a/tests/render_reference.rs
+++ b/tests/render_reference.rs
@@ -9,11 +9,9 @@ use std::io::Cursor;
 
 lazy_static! {
     static ref DEJA_VU_MONO: Font<'static> =
-        Font::from_bytes(include_bytes!("../fonts/dejavu/DejaVuSansMono.ttf") as &[u8])
-            .expect("!DEJA_VU_MONO");
+        Font::from_bytes(include_bytes!("../fonts/dejavu/DejaVuSansMono.ttf") as &[u8]).unwrap();
     static ref OPEN_SANS_ITALIC: Font<'static> =
-        Font::from_bytes(include_bytes!("../fonts/opensans/OpenSans-Italic.ttf") as &[u8])
-            .expect("!DEJA_VU_MONO");
+        Font::from_bytes(include_bytes!("../fonts/opensans/OpenSans-Italic.ttf") as &[u8]).unwrap();
 }
 
 fn draw_luma_alpha(glyph: ScaledGlyph) -> image::GrayAlphaImage {


### PR DESCRIPTION
* Add `From<&AsRef<[u8]>> for SharedBytes` improving lazy_static case ergonomics. Allows:
  ```rust
  lazy_static! {
      static ref BYTES: Vec<u8> = vec![0, 1, 2, 3];
  }
  let shared_bytes: SharedBytes<'static> = (&*BYTES).into();
   ```
* Add `SharedBytes` conversion doc tests.
* Improve image example adding dynamic sizing to more easily switch fonts.
* Remove old confs from rustfmt.toml
* Run rustfmt