### PR TITLE
Swap fnv for fx hashing in gpu-cache hashmaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 * Add `From<&AsRef<[u8]>> for SharedBytes`.
+* Optimise `gpu_cache` hashing to improve benchmark performance by ~30%.
 
 ## 0.6.1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ stb_truetype = "0.2.2"
 ordered-float = "0.5"
 approx = "0.2"
 linked-hash-map = { version = "0.5", optional = true }
-fnv = { version = "1", optional = true }
+rustc-hash = { version = "1", optional = true }
 
 [dev-dependencies]
 glium = "0.21"
@@ -42,7 +42,7 @@ blake2 = "0.7"
 [features]
 # Compiles benchmark code, to be avoided normally as this currently requires nightly rust
 bench = ["gpu_cache"]
-gpu_cache = ["linked-hash-map", "fnv"]
+gpu_cache = ["linked-hash-map", "rustc-hash"]
 
 [[example]]
 name = "gpu_cache"

--- a/src/gpu_cache.rs
+++ b/src/gpu_cache.rs
@@ -38,15 +38,18 @@
 //! cache texture (e.g. due to high cache pressure), construct a new `Cache`
 //! and discard the old one.
 
-extern crate fnv;
 extern crate linked_hash_map;
+extern crate rustc_hash;
 
-use self::fnv::{FnvBuildHasher, FnvHashMap};
 use self::linked_hash_map::LinkedHashMap;
+use self::rustc_hash::{FxHashMap, FxHasher};
 use std::collections::{HashMap, HashSet};
 use std::error;
 use std::fmt;
+use std::hash::BuildHasherDefault;
 use {point, vector, GlyphId, Point, PositionedGlyph, Rect, Vector};
+
+type FxBuildHasher = BuildHasherDefault<FxHasher>;
 
 /// Texture coordinates (floating point) of the quad for a glyph in the cache,
 /// as well as the pixel-space (integer) coordinates that this region should be
@@ -157,13 +160,13 @@ pub struct Cache<'font> {
     position_tolerance: f32,
     width: u32,
     height: u32,
-    rows: LinkedHashMap<u32, Row, FnvBuildHasher>,
+    rows: LinkedHashMap<u32, Row, FxBuildHasher>,
     /// Mapping of row gaps bottom -> top
-    space_start_for_end: FnvHashMap<u32, u32>,
+    space_start_for_end: FxHashMap<u32, u32>,
     /// Mapping of row gaps top -> bottom
-    space_end_for_start: FnvHashMap<u32, u32>,
+    space_end_for_start: FxHashMap<u32, u32>,
     queue: Vec<(FontId, PositionedGlyph<'font>)>,
-    all_glyphs: FnvHashMap<LossyGlyphInfo, TextureRowGlyphIndex>,
+    all_glyphs: FxHashMap<LossyGlyphInfo, TextureRowGlyphIndex>,
     pad_glyphs: bool,
 }
 
@@ -492,7 +495,7 @@ impl<'font> Cache<'font> {
         {
             let (mut in_use_rows, mut uncached_glyphs) = {
                 let mut in_use_rows =
-                    HashSet::with_capacity_and_hasher(self.rows.len(), FnvBuildHasher::default());
+                    HashSet::with_capacity_and_hasher(self.rows.len(), FxBuildHasher::default());
                 let mut uncached_glyphs = Vec::with_capacity(self.queue.len());
 
                 // divide glyphs into texture rows where a matching glyph texture

--- a/src/rasterizer.rs
+++ b/src/rasterizer.rs
@@ -252,7 +252,7 @@ pub fn rasterize<O: FnMut(u32, u32, f32)>(
         scanline_lines.clear();
         scanline_curves.clear();
 
-        for (k, itr) in active_lines_y.iter_mut().enumerate().rev() {
+        for (k, itr) in active_lines_y.iter_mut().enumerate() {
             if let Some(itr) = itr.next() {
                 for line in itr {
                     scanline_lines.push((line, line.x_bounds()))
@@ -261,7 +261,7 @@ pub fn rasterize<O: FnMut(u32, u32, f32)>(
                 lines_to_remove.push(k);
             }
         }
-        for (k, itr) in active_curves_y.iter_mut().enumerate().rev() {
+        for (k, itr) in active_curves_y.iter_mut().enumerate() {
             if let Some(itr) = itr.next() {
                 for curve in itr {
                     scanline_curves.push((curve, curve.x_bounds()))
@@ -271,10 +271,10 @@ pub fn rasterize<O: FnMut(u32, u32, f32)>(
             }
         }
         // remove deactivated segments
-        for k in lines_to_remove.drain(..) {
+        for k in lines_to_remove.drain(..).rev() {
             active_lines_y.swap_remove(k);
         }
-        for k in curves_to_remove.drain(..) {
+        for k in curves_to_remove.drain(..).rev() {
             active_curves_y.swap_remove(k);
         }
         // sort scanline for traversal
@@ -326,7 +326,7 @@ pub fn rasterize<O: FnMut(u32, u32, f32)>(
                 //process x sliced segments for this pixel
                 let mut pixel_value = acc;
                 let mut pixel_acc = 0.0;
-                for (k, itr) in active_lines_x.iter_mut().enumerate().rev() {
+                for (k, itr) in active_lines_x.iter_mut().enumerate() {
                     if let Some(itr) = itr.next() {
                         for mut line in itr {
                             let p = &mut line.p;
@@ -342,7 +342,7 @@ pub fn rasterize<O: FnMut(u32, u32, f32)>(
                         lines_to_remove.push(k);
                     }
                 }
-                for (k, itr) in active_curves_x.iter_mut().enumerate().rev() {
+                for (k, itr) in active_curves_x.iter_mut().enumerate() {
                     if let Some(itr) = itr.next() {
                         for mut curve in itr {
                             let p = &mut curve.p;
@@ -366,10 +366,10 @@ pub fn rasterize<O: FnMut(u32, u32, f32)>(
                 output(x, y, pixel_value.abs());
                 acc += pixel_acc;
                 // remove deactivated segments
-                for k in lines_to_remove.drain(..) {
+                for k in lines_to_remove.drain(..).rev() {
                     active_lines_x.swap_remove(k);
                 }
-                for k in curves_to_remove.drain(..) {
+                for k in curves_to_remove.drain(..).rev() {
                     active_curves_x.swap_remove(k);
                 }
                 x += 1;


### PR DESCRIPTION
I was experimenting with fast integer hashing this weekend, I found _rustc-hash_'s`FxHasher` to generally be faster than fnv for such keys. This proves true here in the gpu_cache usage with around 30% improved benchmark performance.

```
name                                                         control ns/iter  change ns/iter  diff ns/iter   diff %  speedup 
gpu_cache::cache_bench_tests::bench_high_position_tolerance  1,174,522        893,982             -280,540  -23.89%   x 1.31 
gpu_cache::cache_bench_tests::bench_moving_text              1,462,233        1,143,286           -318,947  -21.81%   x 1.28 
gpu_cache::cache_bench_tests::bench_multi_font               1,375,437        1,056,838           -318,599  -23.16%   x 1.30 
gpu_cache::cache_bench_tests::bench_multi_font_population    8,133,369        8,092,911            -40,458   -0.50%   x 1.00 
gpu_cache::cache_bench_tests::bench_single_font              1,318,413        1,007,040           -311,373  -23.62%   x 1.31 
```

Also a minor tweak to the rasterizer, just moving the `.rev()` calls where they make more sense _(they are there just to make the `swap_remove(i)` calls work)_.