### PR TITLE
Fix `non_fmt_panic` warning in ascii example

### DIFF
--- a/dev/examples/ascii.rs
+++ b/dev/examples/ascii.rs
@@ -7,10 +7,7 @@ fn main() {
         let font_path = std::env::current_dir().unwrap().join(font_path);
         let data = std::fs::read(&font_path).unwrap();
         Font::try_from_vec(data).unwrap_or_else(|| {
-            panic!(format!(
-                "error constructing a Font from data at {:?}",
-                font_path
-            ));
+            panic!("error constructing a Font from data at {:?}", font_path);
         })
     } else {
         eprintln!("No font specified ... using WenQuanYiMicroHei.ttf");


### PR DESCRIPTION
`panic!()` supports string formatting natively, and newer rust versions warn about doing anything else, like passing a `String` value