### PR TITLE
Update image.rs

### DIFF
--- a/dev/examples/image.rs
+++ b/dev/examples/image.rs
@@ -38,7 +38,7 @@ fn main() {
     };
 
     // Create a new rgba image with some padding
-    let mut image = DynamicImage::new_rgba8(glyphs_width + 40, glyphs_height + 40).to_rgba();
+    let mut image = DynamicImage::new_rgba8(glyphs_width + 40, glyphs_height + 40).to_rgba8();
 
     // Loop through the glyphs in the text, positing each one on a line
     for glyph in glyphs {


### PR DESCRIPTION
fix error 
```
warning: use of deprecated associated function `image::DynamicImage::to_rgba`: replaced by `to_rgba8`
  --> dev/examples/image.rs:41:84
   |
41 |     let mut image = DynamicImage::new_rgba8(glyphs_width + 40, glyphs_height + 40).to_rgba();
   |                                                                                    ^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: 1 warning emitted

```