### PR TITLE
Upgrade to the latest owned_ttf_parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ exclude = ["/dev/**"]
 features = ["gpu_cache"]
 
 [dependencies]
-owned_ttf_parser = { version = "0.6", default-features = false }
+owned_ttf_parser = { version = "0.9", default-features = false }
 ab_glyph_rasterizer = { version = "0.1.1", default-features = false }
 
 libm = { version = "0.2.1", default-features = false, optional = true }

--- a/dev/examples/ascii.rs
+++ b/dev/examples/ascii.rs
@@ -7,10 +7,7 @@ fn main() {
         let font_path = std::env::current_dir().unwrap().join(font_path);
         let data = std::fs::read(&font_path).unwrap();
         Font::try_from_vec(data).unwrap_or_else(|| {
-            panic!(format!(
-                "error constructing a Font from data at {:?}",
-                font_path
-            ));
+            panic!("error constructing a Font from data at {:?}", font_path);
         })
     } else {
         eprintln!("No font specified ... using WenQuanYiMicroHei.ttf");

--- a/dev/tests/render_reference.rs
+++ b/dev/tests/render_reference.rs
@@ -16,7 +16,7 @@ fn draw_luma_alpha(glyph: ScaledGlyph<'_>) -> image::GrayAlphaImage {
     let glyph = glyph.positioned(point(0.0, 0.0));
     let bounds = glyph.pixel_bounding_box().unwrap();
     let mut glyph_image =
-        DynamicImage::new_luma_a8(bounds.width() as _, bounds.height() as _).to_luma_alpha();
+        DynamicImage::new_luma_a8(bounds.width() as _, bounds.height() as _).to_luma_alpha8();
 
     glyph.draw(|x, y, v| glyph_image.put_pixel(x, y, LumaA([128, (v * 255.0) as u8])));
 
@@ -37,7 +37,7 @@ fn render_to_reference_big_biohazard() {
         image::ImageFormat::Png,
     )
     .expect("!image::load")
-    .to_luma_alpha();
+    .to_luma_alpha8();
 
     assert_eq!(reference.dimensions(), new_image.dimensions());
 
@@ -68,7 +68,7 @@ fn render_to_reference_w() {
         image::ImageFormat::Png,
     )
     .expect("!image::load")
-    .to_luma_alpha();
+    .to_luma_alpha8();
 
     assert_eq!(reference.dimensions(), new_image.dimensions());
 
@@ -99,7 +99,7 @@ fn render_to_reference_iota() {
         image::ImageFormat::Png,
     )
     .expect("!image::load")
-    .to_luma_alpha();
+    .to_luma_alpha8();
 
     assert_eq!(reference.dimensions(), new_image.dimensions());
 
@@ -130,7 +130,7 @@ fn render_to_reference_oft_tailed_e() {
         image::ImageFormat::Png,
     )
     .expect("!image::load")
-    .to_luma_alpha();
+    .to_luma_alpha8();
 
     assert_eq!(reference.dimensions(), new_image.dimensions());
 


### PR DESCRIPTION
Also addresses a few Rust warnings in tests. With #122, all the code,
tests and examples would compile without any warnings.